### PR TITLE
Fix inorder traversal of rooted trees

### DIFF
--- a/src/tree/pll_tree.c
+++ b/src/tree/pll_tree.c
@@ -1418,10 +1418,12 @@ static int rtree_traverse_apply(pll_rnode_t * node,
                                    cb_in_trav,
                                    cb_post_trav,
                                    data);
+  }
 
-    if (cb_in_trav && !cb_in_trav(node,  data))
-      return PLL_FAILURE;
+  if (cb_in_trav && !cb_in_trav(node,  data))
+    return PLL_FAILURE;
 
+  if (node->right) {
     retval &= rtree_traverse_apply(node->right,
                                    cb_pre_trav,
                                    cb_in_trav,


### PR DESCRIPTION
The function registered to be called at the inorder-traversal point was
not executed on the leaves of the rooted tree.